### PR TITLE
Update the 0.5.0 docs to point to the 4.1.0-rc.0 installer

### DIFF
--- a/docs/proc_knative-v050-install-OCP-4x.html
+++ b/docs/proc_knative-v050-install-OCP-4x.html
@@ -155,7 +155,7 @@ This Knative v0.5.0 on OpenShift preview is only available by using the OpenShif
 <i class="fa icon-important" title="Important"></i>
 </td>
 <td class="content">
-Installation requires the OpenShift version <code>0.16.1</code> installer or later. Using the <a href="https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/)">latest version installer</a> is recommended.
+Installation requires the OpenShift version <code>4.1.0-rc.0</code> installer located <a href="https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.1.0-rc.0/">here.</a> Later versions of the installer are not compatible with the Istio version included with this release.
 </td>
 </tr>
 </table>


### PR DESCRIPTION
This is the last version of OCP that works with Istio