### PR TITLE
KafkaChannel is not part of eventing (core)

### DIFF
--- a/docs/proc_knative-eventing.html
+++ b/docs/proc_knative-eventing.html
@@ -172,10 +172,6 @@ ClusterChannelProvisioners have been deprecated and will be removed in future re
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>in-memory</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">InMemoryChannel</p></td>
 </tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>kafka</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">KafkaChannel</p></td>
-</tr>
 </tbody>
 </table>
 </div>


### PR DESCRIPTION
the `KafkaChannel` is not part of the eventing operator.

The `KafkaChannel` is part of the kafka-operator

