### PR TITLE
Updated PR for SRVLOGIC-165: Add a TP and DP notes and change the title to Technology and Developer Preview releases

### DIFF
--- a/modules/ROOT/pages/functions/serverless-functions-about.adoc
+++ b/modules/ROOT/pages/functions/serverless-functions-about.adoc
@@ -1,5 +1,10 @@
 = About buildpacks for OpenShift Serverless Functions
 
+[IMPORTANT]
+====
+Buildpacks for OpenShift Serverless Functions is a Developer Preview feature only. OpenShift Serverless - Developer Preview releases contain features and functionalities that might not be fully tested. Customers are encouraged to provide feedback on Developer Preview releases. Developer Preview releases are not production-ready, and customers are recommended to avoid using the project for production or business-critical workloads.
+====
+
 To improve the process of deployment of your application code, you can use OpenShift Serverless to deploy stateless, event-driven functions as a Knative service on OpenShift Container Platform. If you want to develop functions, you must complete the set up steps.
 
 Function lifecycle management includes creating, building, and deploying a function. Optionally, you can also test a deployed function by invoking it. You can do all of these operations on OpenShift Serverless using the kn func tool.

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -2,14 +2,16 @@
 
 [IMPORTANT]
 ====
-OpenShift Serverless - Developer Preview releases contain features and functionalities that might not be fully tested. Customers are encouraged to provide feedback on Developer Preview releases.
+{serverlessproductname} - Technology and Developer Preview releases contain features and functionalities that might not be fully tested. Customers are encouraged to provide feedback on Technology and Developer Preview releases.
 
-Developer Preview releases are not production-ready, and customers are recommended to avoid using the project for production or business-critical workloads.
+Technology and Developer Preview releases are not production-ready, and customers are recommended to avoid using the project for production or business-critical workloads.
 
-If you need assistance with OpenShift Serverless - Developer Preview releases, please reach out on the following mailing list, where the Red Hat Development Team will be happy to assist you based on the availability and work schedules: serverless-interest@redhat.com
+{serverlessproductname} provides information about additional, advanced use cases and integrations that are possible using OpenShift Container Platform and OpenShift Serverless, but are for technology and development purposes and are not officially supported by Red Hat.
+
+For more information about the support scope of Red Hat Technology Preview features, see https://access.redhat.com/support/offerings/techpreview
+
+If you need assistance with {serverlessproductname} - Technology and Developer Preview releases, please reach out on the serverless-interest@redhat.com mailing list, where the Red Hat Development Team will be happy to assist you based on the availability and work schedules. 
 ====
-
-_OpenShift Serverless_ provides information about additional, advanced use cases and integrations that are possible using OpenShift Container Platform and OpenShift Serverless, but are for development purposes only and are not officially supported by Red Hat.
 
 Before you can complete the tasks documented on this site, you will need a working installation of OpenShift Serverless.
 

--- a/modules/serverless-logic/pages/about.adoc
+++ b/modules/serverless-logic/pages/about.adoc
@@ -1,6 +1,14 @@
 = About OpenShift Serverless Logic
 
-_OpenShift Serverless Logic_ enables developers or architects to define declarative workflow models that orchestrate event-driven, serverless applications. Serverless Logic implements the link:https://github.com/serverlessworkflow/specification[CNCF Serverless Workflow specification], allowing developers and architects to define logical steps of execution declaratively (no code) for cloud-native services. The specification is hosted by the link:https://www.cncf.io/[Cloud Native Computing Foundation (CNCF)] and is currently a link:https://www.cncf.io/projects/serverless-workflow/[CNCF Sandbox project].
+[IMPORTANT]
+====
+OpenShift Serverless Logic is a Technology Preview feature only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
+
+For more information about the support scope of Red Hat Technology Preview
+features, see https://access.redhat.com/support/offerings/techpreview/.
+====
+
+OpenShift Serverless Logic enables developers or architects to define declarative workflow models that orchestrate event-driven, serverless applications. Serverless Logic implements the link:https://github.com/serverlessworkflow/specification[CNCF Serverless Workflow specification], allowing developers and architects to define logical steps of execution declaratively (no code) for cloud-native services. The specification is hosted by the link:https://www.cncf.io/[Cloud Native Computing Foundation (CNCF)] and is currently a link:https://www.cncf.io/projects/serverless-workflow/[CNCF Sandbox project].
 
 OpenShift Serverless Logic is also designed to write workflows in formats (JSON or YAML) that might be better suited for developing and deploying serverless applications in cloud or container environments.
 

--- a/modules/serverless/pages/service-mesh/common-service-mesh-setup.adoc
+++ b/modules/serverless/pages/service-mesh/common-service-mesh-setup.adoc
@@ -5,6 +5,11 @@
 
 This page describes the integration of {serverlessproductname} with {smproductname}.
 
+[IMPORTANT]
+====
+{serverlessproductname} with {SMProductName} is a Developer Preview feature only. {serverlessproductname} - Developer Preview releases contain features and functionalities that might not be fully tested. Customers are encouraged to provide feedback on Developer Preview releases. Developer Preview releases are not production-ready, and customers are recommended to avoid using the project for production or business-critical workloads.
+====
+
 .Assumptions and limitations
 
 * All Knative internal components, as well as Knative Services, are part of the {smproductshortname} and have sidecars injection enabled. This means, that strict mTLS is enforced within the whole mesh. All requests to Knative Services require an mTLS connection (the client must send its certificate), except calls coming from OpenShift Routing.

--- a/modules/serverless/pages/service-mesh/common-service-mesh-setup.adoc
+++ b/modules/serverless/pages/service-mesh/common-service-mesh-setup.adoc
@@ -7,7 +7,10 @@ This page describes the integration of {serverlessproductname} with {smproductna
 
 [IMPORTANT]
 ====
-{serverlessproductname} with {SMProductName} is a Developer Preview feature only. {serverlessproductname} - Developer Preview releases contain features and functionalities that might not be fully tested. Customers are encouraged to provide feedback on Developer Preview releases. Developer Preview releases are not production-ready, and customers are recommended to avoid using the project for production or business-critical workloads.
+{serverlessproductname} with {SMProductName} is is a Technology Preview feature only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
+
+For more information about the support scope of Red Hat Technology Preview
+features, see https://access.redhat.com/support/offerings/techpreview/.
 ====
 
 .Assumptions and limitations

--- a/modules/serverless/pages/serving/serving-with-ingress-sharding.adoc
+++ b/modules/serverless/pages/serving/serving-with-ingress-sharding.adoc
@@ -5,6 +5,11 @@
 
 This page describes how {serverless} Serving can be used with {product-title} ingress sharding.
 
+[IMPORTANT]
+====
+{serverlessproductname} Serving is a Developer Preview feature only. {serverlessproductname} - Developer Preview releases contain features and functionalities that might not be fully tested. Customers are encouraged to provide feedback on Developer Preview releases. Developer Preview releases are not production-ready, and customers are recommended to avoid using the project for production or business-critical workloads.
+====
+
 .Prerequisites
 
 * You have access to an {product-title} account with cluster administrator access.

--- a/supplemental_ui/partials/header-content.hbs
+++ b/supplemental_ui/partials/header-content.hbs
@@ -8,7 +8,7 @@
           <span></span>
         </button>
         <img src="{{uiRootPath}}/img/serverless-icon.png" class="navbar-logo" alt="OpenShift Serverless icon">
-        <a href="">OpenShift Serverless - Developer Preview Releases</a>
+        <a href="">OpenShift Serverless - Technology and Developer Preview Releases</a>
       </div>
     </div>
     <div id="topbar-nav" class="navbar-menu">


### PR DESCRIPTION
**Tracking JIRA:** https://issues.redhat.com/browse/SRVLOGIC-165

**Doc preview:** 
Please check the following sections: 

The overview conveys that this URL covers information that is DP and TP and the respective section mentions that they are TP or DP respectively

- Changed the title of the doc: **OpenShift Serverless - Technology and Developer Preview Releases**

- [Overview](https://deploy-preview-101--jazzy-shortbread-5f62b7.netlify.app/docs/latest/) (**The overview covers the note about both TP and DP**)

- [About OpenShift Serverless Logic](https://deploy-preview-101--jazzy-shortbread-5f62b7.netlify.app/docs/latest/serverless-logic/about) (**Added a TP note**)

- [Setup OpenShift Serverless with OpenShift Service Mesh](https://deploy-preview-101--jazzy-shortbread-5f62b7.netlify.app/docs/latest/serverless/service-mesh/common-service-mesh-setup) (**Added a TP note**)

- [About buildpacks for OpenShift Serverless Functions](https://deploy-preview-101--jazzy-shortbread-5f62b7.netlify.app/docs/latest/functions/serverless-functions-about) (**Added a DP note**)

- [Use Serving with OpenShift ingress sharding](https://deploy-preview-101--jazzy-shortbread-5f62b7.netlify.app/docs/latest/serverless/serving/serving-with-ingress-sharding) (**Added a DP note**)

