### PR TITLE
PR for SRVOCF-504: Removed the content related to "Developing Go functions" section from the midstream (knative) documents

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -101,4 +101,4 @@
 * Buildpacks for Serverless Functions
 ** xref:functions/serverless-functions-about.adoc[About buildpacks for OpenShift Serverless Functions]
 ** xref:functions/serverless-functions-buildpacks.adoc[Building and deploying functions on the cluster]
-** xref:functions/serverless-developing-go-functions.adoc[Developing Go functions]
+//** xref:functions/serverless-developing-go-functions.adoc[Developing Go functions]

--- a/modules/ROOT/pages/functions/serverless-functions-about.adoc
+++ b/modules/ROOT/pages/functions/serverless-functions-about.adoc
@@ -12,4 +12,4 @@ See link:https://docs.openshift.com/container-platform/4.11/serverless/functions
 Some parts of {FunctionsProductName} are in Developer Preview and are documented in the following pages:
 
 * xref:functions/serverless-functions-buildpacks.adoc[Building and deploying functions on the cluster]
-* xref:functions/serverless-developing-go-functions.adoc[Developing Go functions]
+//* xref:functions/serverless-developing-go-functions.adoc[Developing Go functions]


### PR DESCRIPTION
**Affected versions for cherry-picking:** Serverless 1.31

**Tracking JIRA:** https://issues.redhat.com/browse/SRVOCF-504

**Doc preview & Description:** 
[Openshift Serverless - Developer Preview Releases (Midstream documentation)](https://deploy-preview-103--jazzy-shortbread-5f62b7.netlify.app/docs/latest/index.html) 
The "Developing Go functions" section from the midstream (knative) documents is not visible now. (Earlier it was present under the "Buildpacks for Serverless Functions section" but now it has been removed. 