### PR TITLE
PR for SRVOCF-504: Reverting all the changes back in the midstream (knative) documents as the "Go function" is not a tech preview yet.

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -101,4 +101,4 @@
 * Buildpacks for Serverless Functions
 ** xref:functions/serverless-functions-about.adoc[About buildpacks for OpenShift Serverless Functions]
 ** xref:functions/serverless-functions-buildpacks.adoc[Building and deploying functions on the cluster]
-//** xref:functions/serverless-developing-go-functions.adoc[Developing Go functions]
+** xref:functions/serverless-developing-go-functions.adoc[Developing Go functions]

--- a/modules/ROOT/pages/functions/serverless-functions-about.adoc
+++ b/modules/ROOT/pages/functions/serverless-functions-about.adoc
@@ -17,4 +17,4 @@ See link:https://docs.openshift.com/container-platform/4.11/serverless/functions
 Some parts of {FunctionsProductName} are in Developer Preview and are documented in the following pages:
 
 * xref:functions/serverless-functions-buildpacks.adoc[Building and deploying functions on the cluster]
-//* xref:functions/serverless-developing-go-functions.adoc[Developing Go functions]
+* xref:functions/serverless-developing-go-functions.adoc[Developing Go functions]


### PR DESCRIPTION
**Affected versions for cherry-picking:** Serverless 1.31

**Tracking JIRAs:** 
- https://issues.redhat.com/browse/SRVOCF-503
- https://issues.redhat.com/browse/SRVOCF-504

**Doc preview & Description:** 
[Openshift Serverless - Technology and Developer Preview Releases](https://deploy-preview-106--jazzy-shortbread-5f62b7.netlify.app/docs/latest/functions/serverless-developing-go-functions)
The changes have been reverted as the "Go function" is not a tech preview yet. 

The "Developing Go functions" section from the midstream (knative) documents is visible now. It is present under the "Buildpacks for Serverless Functions section".  