### PR TITLE
SRVLOGIC-261-hotfix: Include workflow plugin binary download install

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -106,7 +106,7 @@ asciidoc:
     open_api_spec_url: https://spec.openapis.org/oas/v3.1.0.html
     open_api_swagger_spec_url: https://swagger.io/docs/specification
     quarkus_openapi_gen_url: https://github.com/quarkiverse/quarkus-openapi-generator
-    kie_tools_releases_page_url: https://github.com/apache/incubator-kie-tools/releases
+    kn_workflow_plugin_releases_url: https://developers.redhat.com/content-gateway/rest/mirror/pub/cgw/serverless-logic/1.33.0/
     quarkus_guides_base_url: https://quarkus.io/guides
     quarkus_guides_kafka_url: https://quarkus.io/guides/kafka
     quarkus_guides_building_native: https://quarkus.io/guides/building-native-image

--- a/modules/serverless-logic/pages/cloud/operator/install-kn-workflow-cli.adoc
+++ b/modules/serverless-logic/pages/cloud/operator/install-kn-workflow-cli.adoc
@@ -7,7 +7,40 @@
 
 *Prerequisites*
 
-* You have first installed the  link:{kn_cli_install_url}[Knative CLI].
+* You have first installed the link:{kn_cli_install_url}[Knative CLI].
+* link:{java_install_url}[Java] {java_min_version} is installed.
+* link:{maven_install_url}[Maven] {maven_min_version} or later is installed.
+* (Optional) link:{docker_install_url}[Docker] is installed.
+* (Optional) link:{podman_install_url}[Podman] is installed.
+* link:{kubectl_install_url}[Kubernetes CLI] is installed.
+
+[proc-install-sw-plugin-kn-cli]]
+== Installing the {product_name} plug-in for Knative CLI
+
+You can use the {product_name} plug-in to set up your local workflow project quickly using Knative CLI. 
+
+.Procedure
+. Download the latest binary file, suitable for your environment, from the link:{kn_workflow_plugin_releases_url}[download] page.
+. Install the `kn workflow` command as a plug-in of the Knative CLI using the following steps:
++
+--
+.. Rename the downloaded binary as follows:
++
+`mv kn-workflow-linux-amd64 kn-workflow`
++
+.. Make the binary file executable as follows:
++
+`chmod +x kn-workflow`
++
+[WARNING]
+==== 
+On Mac, some systems might block the application to run due to Apple enforcing policies. To fix this problem, check the *Security & Privacy* section in the *System Preferences* -> *General* tab to approve the application to run. For more information, see link:{apple_support_url}[Apple support article: Open a Mac app from an unidentified developer].
+====
+.. Copy the `kn-workflow` binary file to `/usr/local/bin`.
+.. Run the following command to verify that `kn-workflow` plug-in is installed successfully:
++
+`kn plugin list`
+--
 
 == Installing the Knative Workflow Plugin using the artifacts image
 

--- a/modules/serverless-logic/pages/cloud/operator/install-kn-workflow-cli.adoc
+++ b/modules/serverless-logic/pages/cloud/operator/install-kn-workflow-cli.adoc
@@ -8,11 +8,7 @@
 *Prerequisites*
 
 * You have first installed the link:{kn_cli_install_url}[Knative CLI].
-* link:{java_install_url}[Java] {java_min_version} is installed.
-* link:{maven_install_url}[Maven] {maven_min_version} or later is installed.
-* (Optional) link:{docker_install_url}[Docker] is installed.
-* (Optional) link:{podman_install_url}[Podman] is installed.
-* link:{kubectl_install_url}[Kubernetes CLI] is installed.
+* link:{docker_install_url}[Docker] or {podman_install_url}[Podman] is installed.
 
 [proc-install-sw-plugin-kn-cli]]
 == Installing the {product_name} plug-in for Knative CLI


### PR DESCRIPTION
Add hotfix for https://issues.redhat.com/browse/SRVLOGIC-261

This reintroduces the basic kn workflow plugin install procedure using binary download